### PR TITLE
Fix typo causing stack truncation during all ProgramStates

### DIFF
--- a/Source/ExtendedStorage/_Thing.cs
+++ b/Source/ExtendedStorage/_Thing.cs
@@ -73,7 +73,7 @@ namespace ExtendedStorage
                 }));
                 return;
             }
-            if (Current.ProgramState != ProgramState.MapInitializing || Current.ProgramState != ProgramState.MapPlaying)
+            if (Current.ProgramState != ProgramState.MapInitializing && Current.ProgramState != ProgramState.MapPlaying)
             {
                 if (this.stackCount > this.def.stackLimit)
                 {


### PR DESCRIPTION
Should probably have been && not || - current line will always evaluate to true.
